### PR TITLE
Fix model

### DIFF
--- a/celerybeatmongo/models.py
+++ b/celerybeatmongo/models.py
@@ -28,6 +28,8 @@ class PeriodicTask(Document):
             'allow_inheritance': True}
 
     class Interval(EmbeddedDocument):
+        meta = {'allow_inheritance': True}
+
         every = IntField(min_value=0, default=0, required=True)
         period = StringField(choices=PERIODS)
 
@@ -45,6 +47,8 @@ class PeriodicTask(Document):
             return 'every {0.every} {0.period}'.format(self)
 
     class Crontab(EmbeddedDocument):
+        meta = {'allow_inheritance': True}
+
         minute = StringField(default='*', required=True)
         hour = StringField(default='*', required=True)
         day_of_week = StringField(default='*', required=True)


### PR DESCRIPTION
This PR fix the unbound reference to gettext (removed).

It allows to subclass `PeriodicTask.Crontab` and `PeriodicTask.Interval` making possible to override the `__unicode__` yourself and write:

``` python
# -*- coding: utf-8 -*-
from __future__ import unicode_literals
from celerybeatmongo.models import PeriodicTask as BasePeriodicTask
from i18n import lazy_gettext as _


__all__ = ('PeriodicTask', )


class PeriodicTask(BasePeriodicTask):
    class Interval(BasePeriodicTask.Interval):
        def __unicode__(self):
            if self.every == 1:
                return _('every {0.period_singular}').format(self)
            return _('every {0.every} {0.period}').format(self)
```
