### PR TITLE
Update Mongo Schedule entry to support create task dynamically in application still running

### DIFF
--- a/celerybeatmongo/models.py
+++ b/celerybeatmongo/models.py
@@ -6,9 +6,12 @@
 
 from datetime import datetime, timedelta
 
-from mongoengine import *
 from celery import current_app
 import celery.schedules
+
+from mongoengine.document import DynamicDocument, EmbeddedDocument
+from mongoengine.errors import ValidationError
+from mongoengine.fields import BooleanField, DateTimeField, DictField, EmbeddedDocumentField, IntField, ListField, StringField
 
 
 def get_periodic_task_collection():
@@ -118,7 +121,7 @@ class PeriodicTask(DynamicDocument):
         if not self.date_creation:
             self.date_creation = datetime.now()
         self.date_changed = datetime.now()
-        super(PeriodicTask, self).save(force_insert, validate, clean,
+        return super(PeriodicTask, self).save(force_insert, validate, clean,
                                        write_concern, cascade, cascade_kwargs, _refs,
                                        save_condition, signal_kwargs, **kwargs)
 

--- a/celerybeatmongo/schedulers.py
+++ b/celerybeatmongo/schedulers.py
@@ -132,8 +132,7 @@ class MongoScheduleEntry(ScheduleEntry):
         try:
             return self._task.save(save_condition={})
         except Exception as ex:
-            print(traceback.format_exc())
-            raise ex
+            logger.error(traceback.format_exc())
 
 class MongoScheduler(Scheduler):
 

--- a/celerybeatmongo/schedulers.py
+++ b/celerybeatmongo/schedulers.py
@@ -118,9 +118,10 @@ class MongoScheduleEntry(ScheduleEntry):
             self._task.last_run_at = self.last_run_at
         self._task.run_immediately = False
         try:
-            self._task.save(save_condition={})
-        except Exception:
+            return self._task.save(save_condition={})
+        except Exception as ex:
             print(traceback.format_exc())
+            raise ex
 
 class MongoScheduler(Scheduler):
 


### PR DESCRIPTION
With this change package will be used in app like flask.
I added  change to return object saved in db after.

Example use
celery.py

```
from celery import Celery

config = {
    "mongodb_scheduler_db": "my_project",
    "mongodb_scheduler_url": "mongodb://localhost:27017",
}

app = Celery('hello', broker='redis://localhost//')
app.conf.update(**config)

```

when needed add task in app

```
from celerybeatmongo.models import PeriodicTask
from celerybeatmongo.schedulers import MongoScheduleEntry

task = PeriodicTask(name= 'Importing contacts', task='proj.import_contacts')
task.crontab = PeriodicTask.Crontab(minute="30", hour="7", day_of_week="1",
                           day_of_month="0", month_of_year="*")

entry = MongoScheduleEntry(task=task, app=app)
entry.save()

```

For testing purposes only, post this [file,](https://github.com/dainer88/celerybeat-mongo/releases/download/v0.3.0/celerybeat_mongo-0.3.0-py3-none-any.whl) which will be available until the release of this version.